### PR TITLE
Fixed book-now submit button not showing on mobile

### DIFF
--- a/src/pages/book-now.js
+++ b/src/pages/book-now.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 
 const Div = styled.div`
   width: 100%;
-  height: 100%;
+  height: auto;
   margin-top: 5em;
 `;
 


### PR DESCRIPTION
# Pull Request Details

## Description

On the book-now page, the submit button was being cut off at the bottom of the jotform iframe 
